### PR TITLE
Reduce priority of `Not compressed because too small` errors.

### DIFF
--- a/Sources/KituraCompression/Compression.swift
+++ b/Sources/KituraCompression/Compression.swift
@@ -85,7 +85,7 @@ public class Compression : RouterMiddleware {
         var previousWrittenDataFilter: WrittenDataFilter? = nil
         let writtenDataFilter: WrittenDataFilter = { body in
             guard body.count > self.threshold else {
-                Log.info("Not compressed: body \(body.count) is smaller than the threshold \(self.threshold)")
+                Log.debug("Not compressed: body \(body.count) is smaller than the threshold \(self.threshold)")
                 return previousWrittenDataFilter!(body)
             }
             


### PR DESCRIPTION
It's pretty common (at least in my experience) for there to be a number of files on the average website that are fairly small.  The current implementation logs each time this happens at `info` level, whereas I wouldn't expect the user to care unless they're actively trying to troubleshoot a problem (or at least that's the situation with me and my app).

This just changes a `Log.info` to a `Log.debug`.