### PR TITLE
Be sure and close the stream if compression fails to avoid leaks

### DIFF
--- a/Sources/KituraCompression/Compression.swift
+++ b/Sources/KituraCompression/Compression.swift
@@ -126,6 +126,7 @@ public class Compression : RouterMiddleware {
             guard deflateInit2_(&stream, compressionLevel.rawValue, Z_DEFLATED,
                                 windowBits, memoryLevel, compressionStrategy.rawValue,
                                 ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size)) == Z_OK else {
+                deflateEnd(&stream)
                 return nil
             }
         


### PR DESCRIPTION
This one line of code drops the resident memory set of my current test from ~33M to ~28M