### PR TITLE
Bump Kitura to 2.1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.0.0")),
+        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.1.0")),
         .package(url: "https://github.com/IBM-Swift/CZlib.git", .upToNextMinor(from: "0.1.0"))
     ],
     targets: [


### PR DESCRIPTION
Bump the minor version of the Kitura dependency to 2.1.x, to enable use with 2.1 and avoid SPM resolution problems.

### Motivation and context
Specifically, this avoids a problem where SPM is unable to resolve a Package.swift that specifies (in this order):
```swift
        .package(url: "https://github.com/IBM-Swift/Kitura-Session.git", from: "2.0.0"),
        .package(url: "https://github.com/IBM-Swift/Kitura-Compression.git", from: "2.0.0"),
```
The above package will not resolve (in reasonable time) without swapping the order of the two dependencies, or manually helping SPM to select Kitura 2.0.x, for example including:
```swift
        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.0.0")),
```
What we'd expect to happen is that SPM would identify that Kitura-Compression requires 2.0.x of Kitura, and that Kitura-Session needs to be rolled back to 2.0.x,  but instead it appears to get stuck in an infinite (or at least, very large) loop.