### PR TITLE
Relax dependency on Kitura version to 2.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.1.0")),
+        .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.1.0"),
         .package(url: "https://github.com/IBM-Swift/CZlib.git", .upToNextMinor(from: "0.1.0"))
     ],
     targets: [


### PR DESCRIPTION
Required to use Kitura-Compression with Kitura 2.2.0.

Note that until a new minor of Kitura-Compression is tagged, projects that depend on Kitura `.upToNextMajor(from: "2.0.0")` and Kitura-Compression `.upToNextMajor(from: "2.0.0")` (in that order) will currently hang during SPM dependency resolution, despite there being a valid solution (to roll Kitura back to 2.1.x).

This relaxes the version requirement to Kitura 2.x, which in turn means that a breaking change to the RouterMiddleware API must not be made in a Kitura 2.x minor release (which seems reasonable).