### PR TITLE
Build against Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE=ubuntu:18.04
     - os: osx
       osx_image: xcode9.2
@@ -43,6 +48,10 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.1.0"),
-        .package(url: "/home/djones6/swift5/test2/Kitura-Compression/CZlib", .branch("master"))
+        .package(url: "https://github.com/IBM-Swift/CZlib.git", .upToNextMinor(from: "0.1.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -1,7 +1,7 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 /**
- * Copyright IBM Corporation 2017,2018
+ * Copyright IBM Corporation 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,17 +29,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.1.0"),
+        .package(url: "/home/djones6/swift5/test2/Kitura-Compression/CZlib", .branch("master"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .systemLibrary(
-            name: "CZlib",
-            pkgConfig: "libz",
-            providers: [
-                .apt(["libz-dev"])
-            ]
-        ),
         .target(
             name: "KituraCompression",
             dependencies: ["Kitura", "CZlib"]

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.1.0"),
-        .package(url: "/home/djones6/swift5/test2/Kitura-Compression/CZlib", .branch("master"))
+        .package(url: "https://github.com/IBM-Swift/CZlib.git", .upToNextMinor(from: "0.1.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -1,7 +1,7 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 /**
- * Copyright IBM Corporation 2017,2018
+ * Copyright IBM Corporation 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,17 +29,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.1.0"),
+        .package(url: "/home/djones6/swift5/test2/Kitura-Compression/CZlib", .branch("master"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .systemLibrary(
-            name: "CZlib",
-            pkgConfig: "libz",
-            providers: [
-                .apt(["libz-dev"])
-            ]
-        ),
         .target(
             name: "KituraCompression",
             dependencies: ["Kitura", "CZlib"]

--- a/Sources/CZlib/module.modulemap
+++ b/Sources/CZlib/module.modulemap
@@ -1,0 +1,21 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+ 
+ module CZlib {
+    header "shim.h"
+    link "z"
+    export *
+ }

--- a/Sources/CZlib/shim.h
+++ b/Sources/CZlib/shim.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+ 
+ 
+ #ifndef zlib_shim_h 
+ #define zlib_shim_h
+
+ #import <stdio.h>
+ #import <zlib.h>
+ 
+ #endif


### PR DESCRIPTION
Adds testing with a Swift 5 development snapshot. The snapshot is defined in Travis as `SWIFT_DEVELOPMENT_SNAPSHOT` consistently across the IBM-Swift repos, to enable us to automate updating the version.

Embeds `CZlib` as a system library target for Swift 4.2 and above - this removes a Swift 4.2 compilation warning relating to package structure, and enables building on Swift 5 (since CZlib is currently in Swift 3 format).